### PR TITLE
Fix will_paginate initialization issue

### DIFF
--- a/lib/pager_api/railtie.rb
+++ b/lib/pager_api/railtie.rb
@@ -1,11 +1,8 @@
 module PagerApi
   class Railtie < Rails::Railtie
-
-    initializer "pager_api.action_dispatch" do |app|
-      ActiveSupport.on_load :action_controller do
-        require "pager_api/hooks"
-      end
+    config.after_initialize do
+      require 'pager_api/hooks'
     end
-
   end
 end
+


### PR DESCRIPTION
Fixes issue #11

The hooks are now loaded after the initializer, which resolves an issue
where the gem would default to `kaminari` even though `will_paginate`
was selected.