### PR TITLE
Fix loading pagination helpers for rails 5

### DIFF
--- a/lib/pager_api/railtie.rb
+++ b/lib/pager_api/railtie.rb
@@ -1,8 +1,7 @@
 module PagerApi
   class Railtie < Rails::Railtie
-    config.after_initialize do
+    initializer "pager_api.configure_pagination_helpers" do
       require 'pager_api/hooks'
     end
   end
 end
-


### PR DESCRIPTION
I found that the previous railtie callback was not being called for rails 5.  I'm not too familiar with rails plugins but found this approach works.

I can confirm that adding `include PagerApi::Pagination::Kaminari` to the application controller as in #17 works for development (probably because of autoloading) but not production because the above means the helper files are not required properly.

