### PR TITLE
Adds total_objects to headers

### DIFF
--- a/lib/pager_api.rb
+++ b/lib/pager_api.rb
@@ -12,6 +12,10 @@ module PagerApi
   mattr_accessor :include_pagination_headers
   @@include_pagination_headers = true
 
+  # Total Pages Header name
+  mattr_accessor :total_pages_header
+  @@total_count_header = "X-Total-Pages"
+
   # Total Count Header name
   mattr_accessor :total_count_header
   @@total_count_header = "X-Total-Count"

--- a/lib/pager_api/pagination/kaminari.rb
+++ b/lib/pager_api/pagination/kaminari.rb
@@ -34,7 +34,8 @@ module PagerApi
           end
 
           headers['Link'] = links.join(", ") unless links.empty?
-          headers[PagerApi.total_count_header] = collection.total_pages
+          headers[PagerApi.total_pages_header] = collection.total_pages
+          headers[PagerApi.total_count_header] = collection.total_count
 
           return nil
         end

--- a/lib/pager_api/pagination/will_paginate.rb
+++ b/lib/pager_api/pagination/will_paginate.rb
@@ -35,7 +35,8 @@ module PagerApi
           end
 
           headers['Link'] = links.join(", ") unless links.empty?
-          headers[PagerApi.total_count_header] = collection.total_pages
+          headers[PagerApi.total_pages_header] = collection.total_pages
+          headers[PagerApi.total_count_header] = collection.total_entries
 
           return nil
         end


### PR DESCRIPTION
### What does this PR do?

Currently there is a `PagerApi.total_count_header` config that represents the total pages header instead of the total count, this PR adds a second config `PagerApi.total_pages_header` to send both headers (just like the meta `total_pages`, `total_objects`)
