### PR TITLE
Add page_access_method and per_page_access_method

### DIFF
--- a/lib/pager_api.rb
+++ b/lib/pager_api.rb
@@ -4,6 +4,14 @@ module PagerApi
   mattr_accessor :pagination_handler
   @@pagination_handler = :kaminari
 
+  # page access method
+  mattr_accessor :page_access_method
+  @@page_access_method = :page
+
+  # per page access method
+  mattr_accessor :per_page_access_method
+  @@per_page_access_method = :per
+
   # Meta tag information for pagination
   mattr_accessor :include_pagination_on_meta
   @@include_pagination_on_meta = true
@@ -14,7 +22,7 @@ module PagerApi
 
   # Total Pages Header name
   mattr_accessor :total_pages_header
-  @@total_count_header = "X-Total-Pages"
+  @@total_pages_header = "X-Total-Pages"
 
   # Total Count Header name
   mattr_accessor :total_count_header

--- a/lib/pager_api/pagination/kaminari.rb
+++ b/lib/pager_api/pagination/kaminari.rb
@@ -66,7 +66,7 @@ module PagerApi
           options[:page] = params[:page] || 1
           options[:per_page] = options.delete(:per_page) || params[:per_page] || ::Kaminari.config.default_per_page
 
-          collection.page(options[:page]).per(options[:per_page])
+          collection.send(PagerApi.page_access_method, options[:page]).send(PagerApi.per_page_access_method, options[:per_page])
         end
 
         def meta(collection, options = {})


### PR DESCRIPTION
### What does this PR do?

* Allows to user other methods name, for example, if you use kaminari and will_paginate together and you need to change the pagination method name on kaminari.

Example 
/config/initializers/kaminari_config.rb
`Kaminari.configure do |config|
  # config.default_per_page = 25
  # config.max_per_page = nil
  # config.window = 4
  # config.outer_window = 0
  # config.left = 0
  # config.right = 0
  config.page_method_name = :page_kaminari
  # config.param_name = :page
  # config.params_on_first_page = false
end`
/config/initializers/pager_api.rb
`PagerApi.setup do |config|

  # Pagination Handler
  # User this option to meet your pagination handler, whether is :kaminari or :will_paginate
  config.pagination_handler = :kaminari

  config.page_access_method = :page_kaminari

  # Includes Pagination information on Meta
  #
  config.include_pagination_on_meta = true

  # Includes Pagination information on a Link Header
  #
  # config.include_pagination_headers = true

  # Set the Total-Count Header name
  # config.total_count_header = "X-Total-Count"
end`