### PR TITLE
Add support for specifying custom `:meta` options.

### DIFF
--- a/lib/pager_api/pagination/kaminari.rb
+++ b/lib/pager_api/pagination/kaminari.rb
@@ -70,7 +70,7 @@ module PagerApi
         end
 
         def meta(collection, options = {})
-          {
+          options.fetch(:meta, {}).merge(
             pagination:
             {
               per_page: options[:per_page].to_i || params[:per_page].to_i || ::Kaminari.config.default_per_page,
@@ -78,7 +78,7 @@ module PagerApi
               total_objects: collection.total_count,
               links: pagination_links(collection)
             }
-          }
+          )
         end
 
     end

--- a/lib/pager_api/pagination/pagy.rb
+++ b/lib/pager_api/pagination/pagy.rb
@@ -73,14 +73,14 @@ module PagerApi
       end
 
       def meta(pagy, options = {})
-        {
+        options.fetch(:meta, {}).merge(
           pagination: {
             per_page: pagy.items,
             total_pages: pagy.pages,
             total_objects: pagy.count,
             links: pagination_links(pagy),
           },
-        }
+        )
       end
     end
   end

--- a/lib/pager_api/pagination/will_paginate.rb
+++ b/lib/pager_api/pagination/will_paginate.rb
@@ -71,7 +71,7 @@ module PagerApi
         end
 
         def meta(collection, options = {})
-          {
+          options.fetch(:meta, {}).merge(
             pagination:
             {
               per_page: options[:per_page] || params[:per_page] || ::WillPaginate.per_page,
@@ -79,7 +79,7 @@ module PagerApi
               total_objects: collection.total_entries,
               links: pagination_links(collection)
             }
-          }
+          )
         end
     end
   end


### PR DESCRIPTION
### What does this PR do?

* Currently the pagination implementation completely overwrites the response `:meta` options - I have a use case that requires adding additional options to the meta section but the gem doesn't support that. This change allows something like the following to work as expected:

```
paginate my_collection, meta: { foo: 'bar' }
```

...and will include the specified custom metadata in addition to the pagination metadata.